### PR TITLE
Fix tornado ver w respect momoko (<6.0, >=4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/backend/requirements
+++ b/backend/requirements
@@ -1,4 +1,4 @@
 momoko
-tornado
+tornado <6.0, >=4.0  # momoko 2.2.5.1 has requirement tornado<6.0,>=4.0
 gino
 mimesis


### PR DESCRIPTION
Там на голом `python 3.7`, при установке зависимостей, `momoko` ругается:
`ERROR: momoko 2.2.5.1 has requirement tornado<6.0,>=4.0, but you'll have tornado 6.0.4 which is incompatible.`